### PR TITLE
Add Let's Encrypt certificate rotation via Cloudflare DNS-01

### DIFF
--- a/*Utility/RotateSSLCerts.yml
+++ b/*Utility/RotateSSLCerts.yml
@@ -1,0 +1,24 @@
+---
+- name: Start of Job Monitoring
+  hosts: localhost
+  tasks:
+    - name: Tell Healthchecks.io that we started the playbook
+      ansible.builtin.uri:
+        url: "{{ RotateSSLCertsHC }}/start"
+        timeout: 10
+        force: true
+
+- name: Rotate Let's Encrypt certificates via Cloudflare DNS-01
+  hosts: letsencrypt
+  become: true
+  roles:
+    - letsencrypt-cloudflare
+
+- name: End of Job Monitoring
+  hosts: localhost
+  tasks:
+    - name: Tell Healthchecks.io that we finished the playbook
+      ansible.builtin.uri:
+        url: "{{ RotateSSLCertsHC }}"
+        timeout: 10
+        force: true

--- a/*Utility/RotateSSLCerts.yml
+++ b/*Utility/RotateSSLCerts.yml
@@ -8,6 +8,12 @@
         timeout: 10
         force: true
 
+- name: Deploy Bitwarden cert rotation hook script
+  hosts: bitwarden
+  become: true
+  roles:
+    - bitwarden
+
 - name: Rotate Let's Encrypt certificates via Cloudflare DNS-01
   hosts: letsencrypt
   become: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ The repository is expanding to manage the entire home network across multiple ne
 - `WordpressUpdater.yml`: Update all WP plugins, themes, and core (runs nightly)
 - `ClearNginxCache.yml`: Clear FastCGI cache after major site changes
 - `ReloadWeb.yml`: Reload nginx config on web/wp-admin servers
+- `RotateSSLCerts.yml`: Issue/renew Let's Encrypt certs via Cloudflare DNS-01 challenge (no port 80/443 exposure needed); intended to run weekly
 
 ### Roles
 
@@ -73,6 +74,7 @@ The repository is expanding to manage the entire home network across multiple ne
 - `nfs-client`: NFS client mount configuration
 - `zabbix-agent`: Monitoring agent installation
 - `control`: Control server configuration
+- `letsencrypt-cloudflare`: Issues/renews Let's Encrypt certs via certbot's DNS-01 Cloudflare plugin; opt in per host via `letsencrypt_certificates` in host_vars, targeted via the `letsencrypt` host group
 
 ### Host Groups
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ The repository is expanding to manage the entire home network across multiple ne
 - `zabbix-agent`: Monitoring agent installation
 - `control`: Control server configuration
 - `letsencrypt-cloudflare`: Issues/renews Let's Encrypt certs via certbot's DNS-01 Cloudflare plugin; opt in per host via `letsencrypt_certificates` in host_vars, targeted via the `letsencrypt` host group
+- `bitwarden`: Drops a deploy-hook script that copies renewed certs into the official self-hosted Bitwarden's `bwdata/ssl/` and runs `bitwarden.sh restart`; targeted via the `bitwarden` host group
 
 ### Host Groups
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The official [self-hosted Bitwarden Linux install](https://bitwarden.com/help/in
 Tag the Bitwarden host with both the `letsencrypt` and `bitwarden` Proxmox tags, then in its `host_vars`:
 ```yaml
 bitwarden_domain: vault.slamautils.com   # exact FQDN bitwarden.sh was configured with
-# bitwarden_install_dir: /opt/bitwarden   # only needed if you installed somewhere else
+# bitwarden_install_dir: /home/bitwarden  # default, override if installed elsewhere
 
 letsencrypt_certificates:
   - name: bitwarden

--- a/README.md
+++ b/README.md
@@ -47,3 +47,18 @@ Currently these playbooks assume a couple things, this is being worked on and th
  - `ClearNginxCache.yml` - Clears the FastCGI cache for a website. Useful to run this after making big changes to a site.
  - `ReloadWeb.yml` - Reloads the configuration for all of the Web and WPAdmin servers. Run after making nginx config changes. 
  - `WordpressUpdater.yml` - Updates all Plugins, all Themes, and the core Wordpress version for all WordPress sites on the cluster. *Meant to be run on a schedule/cron. Daily*
+ - `RotateSSLCerts.yml` - Issues/renews Let's Encrypt certificates via DNS-01 validation against the Cloudflare API (no port 80/443 required). *Meant to be run on a schedule/cron. Weekly*
+
+### SSL Certificate Rotation (`RotateSSLCerts.yml`)
+Uses `certbot` with the `certbot-dns-cloudflare` plugin, so certs can be issued for hosts that aren't internet-reachable on port 80/443 - Cloudflare DNS is used to satisfy the ACME challenge instead.
+
+1. Tag any host that needs a cert with the Proxmox tag `letsencrypt` (this becomes the `letsencrypt` inventory group).
+2. Define a `letsencrypt_certificates` list in that host's `host_vars`:
+   ```yaml
+   letsencrypt_certificates:
+     - name: zabbix                            # cert lives at /etc/letsencrypt/live/<name>/
+       domains:
+         - zabbix.example.com
+       deploy_hook: "systemctl reload nginx"    # optional, only runs when the cert actually changes
+   ```
+3. Set `CloudflareApiToken` (scoped to `Zone:DNS:Edit` on the relevant zone only) and `LetsEncryptEmail` in the Semaphore Variable Group, per `extra_vars_TEMPLATE.yml`.

--- a/README.md
+++ b/README.md
@@ -62,3 +62,18 @@ Uses `certbot` with the `certbot-dns-cloudflare` plugin, so certs can be issued 
        deploy_hook: "systemctl reload nginx"    # optional, only runs when the cert actually changes
    ```
 3. Set `CloudflareApiToken` (scoped to `Zone:DNS:Edit` on the relevant zone only) and `LetsEncryptEmail` in the Semaphore Variable Group, per `extra_vars_TEMPLATE.yml`.
+
+#### Bitwarden example
+The official [self-hosted Bitwarden Linux install](https://bitwarden.com/help/install-on-premise-linux/) expects its cert/key at `<install_dir>/bwdata/ssl/<domain>/<domain>.crt` and `.key`, then needs `bitwarden.sh restart` to pick them up. The `bitwarden` role drops a small script that does exactly that, wired up as the cert's `deploy_hook` so it only runs when the cert actually renews.
+
+Tag the Bitwarden host with both the `letsencrypt` and `bitwarden` Proxmox tags, then in its `host_vars`:
+```yaml
+bitwarden_domain: vault.slamautils.com   # exact FQDN bitwarden.sh was configured with
+# bitwarden_install_dir: /opt/bitwarden   # only needed if you installed somewhere else
+
+letsencrypt_certificates:
+  - name: bitwarden
+    domains:
+      - "*.slamautils.com"
+    deploy_hook: "/usr/local/sbin/deploy-bitwarden-cert.sh"
+```

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,6 +2,10 @@
 # Inventory configuration
 inventory = inventory.proxmox.yml
 
+# Shared roles directory, so playbooks under *Lifecycle/ and *Utility/ can
+# also resolve roles defined at the repo root (not just root-level playbooks)
+roles_path = roles
+
 # Connection settings
 remote_user = ansible
 private_key_file = ~/.ssh/id_ed25519

--- a/extra_vars_TEMPLATE.yml
+++ b/extra_vars_TEMPLATE.yml
@@ -2,5 +2,10 @@
 #Healthchecks.io
 WordpressUpdaterHC: https://hc-ping.com/123123asdasd12eqsd
 SitePlaybookHC: https://hc-ping.com/as3edawdasdasdsad
+RotateSSLCertsHC: https://hc-ping.com/exampleexampleexample
 # HAProxy
 HAProxyStatsPassword: ExamplePassword
+# Let's Encrypt / Cloudflare DNS-01 cert rotation
+# CloudflareApiToken needs Zone:DNS:Edit scope on the relevant zone(s) only.
+CloudflareApiToken: ExampleCloudflareApiToken
+LetsEncryptEmail: admin@example.com

--- a/host_vars/Slama-Read-Pass01v.yml
+++ b/host_vars/Slama-Read-Pass01v.yml
@@ -1,6 +1,6 @@
 ---
 bitwarden_domain: valkyrie.slamautils.com
-# bitwarden_install_dir: /opt/bitwarden   # default, uncomment to override
+# bitwarden_install_dir: /home/bitwarden   # default
 
 letsencrypt_certificates:
   - name: bitwarden

--- a/host_vars/Slama-Read-Pass01v.yml
+++ b/host_vars/Slama-Read-Pass01v.yml
@@ -1,0 +1,9 @@
+---
+bitwarden_domain: valkyrie.slamautils.com
+# bitwarden_install_dir: /opt/bitwarden   # default, uncomment to override
+
+letsencrypt_certificates:
+  - name: bitwarden
+    domains:
+      - "*.slamautils.com"
+    deploy_hook: "/usr/local/sbin/deploy-bitwarden-cert.sh"

--- a/roles/bitwarden/defaults/main.yml
+++ b/roles/bitwarden/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Path the official bitwarden.sh installer was run from (contains bitwarden.sh and bwdata/)
-bitwarden_install_dir: /opt/bitwarden
+bitwarden_install_dir: /home/bitwarden
 
 # Must match the `name` used in this host's letsencrypt_certificates entry,
 # so the deploy script knows which /etc/letsencrypt/live/<name>/ to pull from.

--- a/roles/bitwarden/defaults/main.yml
+++ b/roles/bitwarden/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+# Path the official bitwarden.sh installer was run from (contains bitwarden.sh and bwdata/)
+bitwarden_install_dir: /opt/bitwarden
+
+# Must match the `name` used in this host's letsencrypt_certificates entry,
+# so the deploy script knows which /etc/letsencrypt/live/<name>/ to pull from.
+bitwarden_letsencrypt_cert_name: bitwarden

--- a/roles/bitwarden/tasks/main.yml
+++ b/roles/bitwarden/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Deploy Bitwarden cert rotation script
+  ansible.builtin.template:
+    src: deploy-cert.sh.j2
+    dest: /usr/local/sbin/deploy-bitwarden-cert.sh
+    owner: root
+    group: root
+    mode: '0700'

--- a/roles/bitwarden/templates/deploy-cert.sh.j2
+++ b/roles/bitwarden/templates/deploy-cert.sh.j2
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Managed by Ansible - do not edit by hand.
+# Invoked by certbot's --deploy-hook (see roles/letsencrypt-cloudflare) only
+# when a certificate has actually been issued/renewed.
+set -euo pipefail
+
+CERT_NAME="{{ bitwarden_letsencrypt_cert_name }}"
+DOMAIN="{{ bitwarden_domain }}"
+SSL_DIR="{{ bitwarden_install_dir }}/bwdata/ssl/${DOMAIN}"
+
+mkdir -p "${SSL_DIR}"
+cp "/etc/letsencrypt/live/${CERT_NAME}/fullchain.pem" "${SSL_DIR}/${DOMAIN}.crt"
+cp "/etc/letsencrypt/live/${CERT_NAME}/privkey.pem" "${SSL_DIR}/${DOMAIN}.key"
+chmod 644 "${SSL_DIR}/${DOMAIN}.crt"
+chmod 600 "${SSL_DIR}/${DOMAIN}.key"
+
+"{{ bitwarden_install_dir }}/bitwarden.sh" restart

--- a/roles/bitwarden/templates/deploy-cert.sh.j2
+++ b/roles/bitwarden/templates/deploy-cert.sh.j2
@@ -14,4 +14,4 @@ cp "/etc/letsencrypt/live/${CERT_NAME}/privkey.pem" "${SSL_DIR}/private.key"
 chmod 644 "${SSL_DIR}/certificate.crt"
 chmod 600 "${SSL_DIR}/private.key"
 
-"{{ bitwarden_install_dir }}/bitwarden.sh" restart
+sudo -u bitwarden "{{ bitwarden_install_dir }}/bitwarden.sh" restart

--- a/roles/bitwarden/templates/deploy-cert.sh.j2
+++ b/roles/bitwarden/templates/deploy-cert.sh.j2
@@ -6,12 +6,12 @@ set -euo pipefail
 
 CERT_NAME="{{ bitwarden_letsencrypt_cert_name }}"
 DOMAIN="{{ bitwarden_domain }}"
-SSL_DIR="{{ bitwarden_install_dir }}/bwdata/ssl/${DOMAIN}"
+SSL_DIR="{{ bitwarden_install_dir }}/bwdata/ssl/self/${DOMAIN}"
 
 mkdir -p "${SSL_DIR}"
-cp "/etc/letsencrypt/live/${CERT_NAME}/fullchain.pem" "${SSL_DIR}/${DOMAIN}.crt"
-cp "/etc/letsencrypt/live/${CERT_NAME}/privkey.pem" "${SSL_DIR}/${DOMAIN}.key"
-chmod 644 "${SSL_DIR}/${DOMAIN}.crt"
-chmod 600 "${SSL_DIR}/${DOMAIN}.key"
+cp "/etc/letsencrypt/live/${CERT_NAME}/fullchain.pem" "${SSL_DIR}/certificate.crt"
+cp "/etc/letsencrypt/live/${CERT_NAME}/privkey.pem" "${SSL_DIR}/private.key"
+chmod 644 "${SSL_DIR}/certificate.crt"
+chmod 600 "${SSL_DIR}/private.key"
 
 "{{ bitwarden_install_dir }}/bitwarden.sh" restart

--- a/roles/letsencrypt-cloudflare/defaults/main.yml
+++ b/roles/letsencrypt-cloudflare/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+# How long to wait for the Cloudflare TXT record to propagate before
+# Let's Encrypt is asked to validate the DNS-01 challenge.
+letsencrypt_dns_propagation_seconds: 30
+
+# Per-host list of certificates to issue/renew. Define this in host_vars
+# for any host that needs a cert, e.g.:
+#
+# letsencrypt_certificates:
+#   - name: zabbix                       # becomes /etc/letsencrypt/live/<name>/
+#     domains:
+#       - zabbix.example.com
+#     deploy_hook: "systemctl reload nginx"   # optional, only runs when the cert actually changes
+letsencrypt_certificates: []

--- a/roles/letsencrypt-cloudflare/tasks/main.yml
+++ b/roles/letsencrypt-cloudflare/tasks/main.yml
@@ -1,0 +1,38 @@
+---
+- name: Install certbot and the Cloudflare DNS plugin
+  ansible.builtin.apt:
+    name: "{{ sys_packages }}"
+    state: present
+    update_cache: true
+
+- name: Disable certbot's built-in renewal timer
+  ansible.builtin.systemd:
+    name: certbot.timer
+    enabled: false
+    state: stopped
+  failed_when: false
+
+- name: Deploy Cloudflare API credentials for DNS-01 challenges
+  ansible.builtin.template:
+    src: cloudflare-credentials.ini.j2
+    dest: /etc/letsencrypt/cloudflare.ini
+    owner: root
+    group: root
+    mode: '0600'
+
+- name: Request/renew certificates via Let's Encrypt DNS-01 (Cloudflare)
+  ansible.builtin.command:
+    cmd: >-
+      certbot certonly --non-interactive --agree-tos --expand
+      --email {{ LetsEncryptEmail }}
+      --dns-cloudflare
+      --dns-cloudflare-credentials /etc/letsencrypt/cloudflare.ini
+      --dns-cloudflare-propagation-seconds {{ letsencrypt_dns_propagation_seconds }}
+      --cert-name {{ item.name }}
+      {% for domain in item.domains %}-d {{ domain }} {% endfor %}
+      {% if item.deploy_hook is defined %}--deploy-hook "{{ item.deploy_hook }}"{% endif %}
+  register: certbot_result
+  changed_when: "'no action taken' not in certbot_result.stdout"
+  loop: "{{ letsencrypt_certificates }}"
+  loop_control:
+    label: "{{ item.name }}"

--- a/roles/letsencrypt-cloudflare/templates/cloudflare-credentials.ini.j2
+++ b/roles/letsencrypt-cloudflare/templates/cloudflare-credentials.ini.j2
@@ -1,0 +1,2 @@
+# Managed by Ansible - do not edit by hand.
+dns_cloudflare_api_token = {{ CloudflareApiToken }}

--- a/roles/letsencrypt-cloudflare/vars/main.yml
+++ b/roles/letsencrypt-cloudflare/vars/main.yml
@@ -1,0 +1,2 @@
+---
+sys_packages: [ 'certbot', 'python3-certbot-dns-cloudflare' ]


### PR DESCRIPTION
## Summary

Adds automated SSL certificate issuance and renewal using Let's Encrypt with DNS-01 validation via Cloudflare, enabling certificate management for hosts not exposed on ports 80/443. Includes a new utility playbook and supporting roles for general use and Bitwarden-specific deployment.

## Key Changes

- **New Playbook**: `RotateSSLCerts.yml` - Weekly utility playbook for certificate rotation with healthchecks.io monitoring integration
- **New Role**: `letsencrypt-cloudflare` - Installs certbot with Cloudflare DNS plugin, deploys API credentials, and manages certificate lifecycle via DNS-01 challenges
- **New Role**: `bitwarden` - Bitwarden-specific certificate deployment hook that copies renewed certs to Bitwarden's expected location and restarts the service
- **Configuration**: Added `CloudflareApiToken` and `LetsEncryptEmail` to `extra_vars_TEMPLATE.yml`
- **Inventory**: Added example host configuration for Bitwarden cert rotation
- **Documentation**: Updated README with SSL certificate rotation workflow and examples for both generic and Bitwarden deployments
- **Build Config**: Updated `ansible.cfg` to include shared `roles_path` so utility playbooks can resolve roles

## Implementation Details

- Hosts opt-in via Proxmox `letsencrypt` tag (becomes inventory group)
- Per-host certificate definitions in `host_vars` specify domain list and optional deploy hooks
- Deploy hooks only execute when certificates actually change (via `changed_when` condition)
- Cloudflare API token scoped to `Zone:DNS:Edit` for security
- Bitwarden deployment script handles cert/key placement and service restart
- Certbot's built-in renewal timer disabled in favor of scheduled playbook execution

https://claude.ai/code/session_011PT5jXNZruU5cL2FmzEZRq